### PR TITLE
xcrun can't be used to find itself in XC 8

### DIFF
--- a/lib/xcinvoke/xcode.rb
+++ b/lib/xcinvoke/xcode.rb
@@ -75,9 +75,7 @@ module XCInvoke
     def xcrun(cmd, env: {}, err: false)
       env = env.merge(as_env)
 
-      # explicitly dont use the env when computing the full path to xcrun
-      @xcrun_path ||= Open3.capture2('xcrun', '-f', 'xcrun').first.strip
-      cmd = [@xcrun_path] + cmd
+      cmd = ['xcrun'] + cmd
       case err
       when :merge
         oe, = Open3.capture2e(env, *cmd)

--- a/lib/xcinvoke/xcode.rb
+++ b/lib/xcinvoke/xcode.rb
@@ -75,7 +75,15 @@ module XCInvoke
     def xcrun(cmd, env: {}, err: false)
       env = env.merge(as_env)
 
-      cmd = ['xcrun'] + cmd
+      # xcrun self-lookup is a workaround for issues caused by having
+      # multiple very old versions of Xcode installed
+      # (see https://github.com/segiddins/xcinvoke/issues/3)
+      @xcrun_path ||= Open3.capture3('xcrun', '-f', 'xcrun').first.strip
+
+      # Env-based lookup is necessary for Xcode ≥8
+      @xcrun_path = 'xcrun' if @xcrun_path == ''
+
+      cmd = [@xcrun_path] + cmd
       case err
       when :merge
         oe, = Open3.capture2e(env, *cmd)


### PR DESCRIPTION
Fixes #6.

I’m nervous about removing this curious logic, which seems to be there for a reason — but #6 currently appears to be breaking all projects on CocoaDocs that specify a `swift_version` in their Jazzy config, and this fix works for me.
